### PR TITLE
Fix UTType for none export option

### DIFF
--- a/AdventureRecords/Core/Data/CoreDataManager.swift
+++ b/AdventureRecords/Core/Data/CoreDataManager.swift
@@ -70,7 +70,7 @@ enum ExportType {
         case .json:
             return .json
         case .none:
-            return .pdf
+            return .data
         }
     }
 }


### PR DESCRIPTION
## Summary
- adjust `ExportType.utType` to return `.data` for `.none`

## Testing
- `swiftformat --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684203e67cec8325aae198074f89ab4d