### PR TITLE
Add basic backup creation test

### DIFF
--- a/AdventureRecordsTests/CoreDataBackupTests.swift
+++ b/AdventureRecordsTests/CoreDataBackupTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import AdventureRecords
+
+final class CoreDataBackupTests: XCTestCase {
+    func testCreateBackupGeneratesFile() throws {
+        // Generate sample data
+        SampleDataGenerator.initializeData()
+        let manager = CoreDataManager.shared
+
+        // Record existing backups
+        let existingBackups = manager.getAllBackups()
+
+        // Create backup
+        let now = Date()
+        let _ = manager.createBackup(name: "TestBackup", date: now)
+
+        // Fetch backups after creation
+        let allBackups = manager.getAllBackups()
+        let newBackups = allBackups.filter { !existingBackups.contains($0) && $0.name.contains("TestBackup") }
+        XCTAssertFalse(newBackups.isEmpty, "Backup file should be created")
+
+        // Cleanup new backup files
+        for backup in newBackups {
+            try? FileManager.default.removeItem(at: backup.url)
+        }
+    }
+}

--- a/AdventureRecordsTests/CoreDataCRUDTests.swift
+++ b/AdventureRecordsTests/CoreDataCRUDTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import AdventureRecords
+
+final class CoreDataCRUDTests: XCTestCase {
+    override func setUp() {
+        _ = CoreDataManager.shared.cleanupData(type: .all)
+    }
+
+    override func tearDown() {
+        _ = CoreDataManager.shared.cleanupData(type: .all)
+    }
+
+    func testCharacterCRUD() {
+        let manager = CoreDataManager.shared
+        let character = manager.createCharacter(name: "TestChar", description: "desc")
+        var fetched = manager.fetchCharacters().first { $0.id == character.id }
+        XCTAssertNotNil(fetched)
+
+        var updated = character
+        updated.name = "UpdatedChar"
+        manager.updateCharacter(updated)
+
+        fetched = manager.fetchCharacters().first { $0.id == character.id }
+        XCTAssertEqual(fetched?.name, "UpdatedChar")
+
+        manager.deleteCharacter(character.id)
+        fetched = manager.fetchCharacters().first { $0.id == character.id }
+        XCTAssertNil(fetched)
+    }
+
+    func testSceneCRUD() {
+        let manager = CoreDataManager.shared
+        let scene = manager.createScene(title: "TestScene", description: "desc")
+        var fetched = manager.fetchScenes().first { $0.id == scene.id }
+        XCTAssertNotNil(fetched)
+
+        var updated = scene
+        updated.title = "UpdatedScene"
+        manager.updateScene(updated)
+        fetched = manager.fetchScenes().first { $0.id == scene.id }
+        XCTAssertEqual(fetched?.title, "UpdatedScene")
+
+        manager.deleteScene(scene.id)
+        fetched = manager.fetchScenes().first { $0.id == scene.id }
+        XCTAssertNil(fetched)
+    }
+
+    func testNoteCRUD() {
+        let manager = CoreDataManager.shared
+        let note = manager.createNote(title: "TestNote", content: "content")
+        var fetched = manager.fetchNotes().first { $0.id == note.id }
+        XCTAssertNotNil(fetched)
+
+        var updated = note
+        updated.title = "UpdatedNote"
+        manager.updateNote(updated)
+
+        fetched = manager.fetchNotes().first { $0.id == note.id }
+        XCTAssertEqual(fetched?.title, "UpdatedNote")
+
+        manager.deleteNote(note.id)
+        fetched = manager.fetchNotes().first { $0.id == note.id }
+        XCTAssertNil(fetched)
+    }
+}

--- a/AdventureRecordsTests/ExportAndCleanupTests.swift
+++ b/AdventureRecordsTests/ExportAndCleanupTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import AdventureRecords
+
+final class ExportAndCleanupTests: XCTestCase {
+    override func setUp() {
+        _ = CoreDataManager.shared.cleanupData(type: .all)
+        SampleDataGenerator.initializeData()
+    }
+
+    override func tearDown() {
+        _ = CoreDataManager.shared.cleanupData(type: .all)
+    }
+
+    func testExportJSONIncludesAllSections() throws {
+        let manager = CoreDataManager.shared
+        guard let document = manager.exportData(type: .json, includeCharacters: true, includeScenes: true, includeNotes: true) else {
+            XCTFail("Expected export document")
+            return
+        }
+        let jsonObject = try JSONSerialization.jsonObject(with: document.data, options: []) as? [String: Any]
+        XCTAssertNotNil(jsonObject?["characters"])
+        XCTAssertNotNil(jsonObject?["scenes"])
+        XCTAssertNotNil(jsonObject?["notes"])
+    }
+}

--- a/AdventureRecordsTests/SampleDataTests.swift
+++ b/AdventureRecordsTests/SampleDataTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import AdventureRecords
+
+final class SampleDataTests: XCTestCase {
+    override func setUp() {
+        _ = CoreDataManager.shared.cleanupData(type: .all)
+    }
+
+    override func tearDown() {
+        _ = CoreDataManager.shared.cleanupData(type: .all)
+    }
+
+    func testInitializeSampleDataCreatesRecords() {
+        SampleDataGenerator.initializeData()
+        let manager = CoreDataManager.shared
+        XCTAssertGreaterThan(manager.fetchCharacters().count, 0)
+        XCTAssertGreaterThan(manager.fetchScenes().count, 0)
+        XCTAssertGreaterThan(manager.fetchNotes().count, 0)
+    }
+
+    func testCleanupRemovesAllData() {
+        SampleDataGenerator.initializeData()
+        let manager = CoreDataManager.shared
+        XCTAssertFalse(manager.fetchCharacters().isEmpty)
+        let success = manager.cleanupData(type: .all)
+        XCTAssertTrue(success)
+        XCTAssertTrue(manager.fetchCharacters().isEmpty)
+        XCTAssertTrue(manager.fetchScenes().isEmpty)
+        XCTAssertTrue(manager.fetchNotes().isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- add XCTest target directory `AdventureRecordsTests/`
- create `CoreDataBackupTests` which creates a backup using sample data and verifies a file is produced
- add more unit tests for sample data generation, CRUD operations, JSON export, and data cleanup

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684203d265f083258fa509e7a2d0205c