### PR TITLE
Add additional unit tests for backups and audio

### DIFF
--- a/AdventureRecordsTests/AudioRecordingTests.swift
+++ b/AdventureRecordsTests/AudioRecordingTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import AdventureRecords
+
+final class AudioRecordingTests: XCTestCase {
+    let manager = CoreDataManager.shared
+    override func setUp() {
+        _ = manager.cleanupData(type: .all)
+    }
+    override func tearDown() {
+        _ = manager.cleanupData(type: .all)
+        let doc = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let audios = doc.appendingPathComponent("AudioRecordings")
+        try? FileManager.default.removeItem(at: audios)
+    }
+
+    func testSaveFetchUpdateDeleteRecording() throws {
+        let audioDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("AudioRecordings")
+        try FileManager.default.createDirectory(at: audioDir, withIntermediateDirectories: true)
+        let id = UUID()
+        let audioURL = audioDir.appendingPathComponent("\(id.uuidString).m4a")
+        try Data("audio".utf8).write(to: audioURL)
+
+        var recording = AudioRecording(id: id, title: "Original", recordingURL: audioURL, date: Date())
+        manager.saveAudioRecording(recording)
+
+        var fetched = manager.fetchAudioRecordings().first { $0.id == id }
+        XCTAssertNotNil(fetched)
+        XCTAssertEqual(fetched?.title, "Original")
+
+        recording.title = "Updated"
+        manager.updateAudioRecording(recording)
+
+        fetched = manager.fetchAudioRecordings().first { $0.id == id }
+        XCTAssertEqual(fetched?.title, "Updated")
+
+        manager.deleteAudioRecording(id)
+        fetched = manager.fetchAudioRecordings().first { $0.id == id }
+        XCTAssertNil(fetched)
+
+        try? FileManager.default.removeItem(at: audioURL)
+    }
+}

--- a/AdventureRecordsTests/BackupRestoreTests.swift
+++ b/AdventureRecordsTests/BackupRestoreTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import AdventureRecords
+
+final class BackupRestoreTests: XCTestCase {
+    let manager = CoreDataManager.shared
+
+    override func setUp() {
+        _ = manager.cleanupData(type: .all)
+    }
+
+    override func tearDown() {
+        _ = manager.cleanupData(type: .all)
+        // Remove backup directory
+        let backups = manager.getAllBackups()
+        for backup in backups {
+            try? FileManager.default.removeItem(at: backup.url)
+        }
+        // Remove audio directories
+        let doc = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let recordings = doc.appendingPathComponent("Recordings")
+        try? FileManager.default.removeItem(at: recordings)
+        let audios = doc.appendingPathComponent("AudioRecordings")
+        try? FileManager.default.removeItem(at: audios)
+    }
+
+    func testBackupAndRestoreData() throws {
+        // Create sample records
+        SampleDataGenerator.initializeData()
+
+        // Create a dummy audio file and save recording
+        let audioDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("AudioRecordings")
+        try FileManager.default.createDirectory(at: audioDir, withIntermediateDirectories: true)
+        let recID = UUID()
+        let audioURL = audioDir.appendingPathComponent("\(recID.uuidString).m4a")
+        try Data("test".utf8).write(to: audioURL)
+        let recording = AudioRecording(id: recID, title: "Sample", recordingURL: audioURL, date: Date())
+        manager.saveAudioRecording(recording)
+
+        // Create backup
+        let _ = manager.createBackup(name: "RestoreTest", date: Date())
+        guard let backup = manager.getAllBackups().first(where: { $0.name.contains("RestoreTest") }) else {
+            XCTFail("Expected backup file")
+            return
+        }
+
+        // Clean existing data and audio
+        _ = manager.cleanupData(type: .all)
+        try? FileManager.default.removeItem(at: audioURL)
+
+        // Restore
+        let success = manager.restoreFromBackup(backup)
+        XCTAssertTrue(success, "Restore should succeed")
+        XCTAssertFalse(manager.fetchCharacters().isEmpty)
+        XCTAssertFalse(manager.fetchScenes().isEmpty)
+        XCTAssertFalse(manager.fetchNotes().isEmpty)
+        XCTAssertFalse(manager.fetchAudioRecordings().isEmpty)
+
+        // Verify audio file restored
+        let expectedURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("Recordings")
+            .appendingPathComponent("\(recID.uuidString).m4a")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: expectedURL.path))
+    }
+}

--- a/AdventureRecordsTests/CoreDataBackupTests.swift
+++ b/AdventureRecordsTests/CoreDataBackupTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import AdventureRecords
+
+final class CoreDataBackupTests: XCTestCase {
+    func testCreateBackupGeneratesFile() throws {
+        // Generate sample data
+        SampleDataGenerator.initializeData()
+        let manager = CoreDataManager.shared
+
+        // Record existing backups
+        let existingBackups = manager.getAllBackups()
+
+        // Create backup
+        let now = Date()
+        let _ = manager.createBackup(name: "TestBackup", date: now)
+
+        // Fetch backups after creation
+        let allBackups = manager.getAllBackups()
+        let newBackups = allBackups.filter { !existingBackups.contains($0) && $0.name.contains("TestBackup") }
+        XCTAssertFalse(newBackups.isEmpty, "Backup file should be created")
+
+        // Cleanup new backup files
+        for backup in newBackups {
+            try? FileManager.default.removeItem(at: backup.url)
+        }
+    }
+}

--- a/AdventureRecordsTests/CoreDataCRUDTests.swift
+++ b/AdventureRecordsTests/CoreDataCRUDTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import AdventureRecords
+
+final class CoreDataCRUDTests: XCTestCase {
+    override func setUp() {
+        _ = CoreDataManager.shared.cleanupData(type: .all)
+    }
+
+    override func tearDown() {
+        _ = CoreDataManager.shared.cleanupData(type: .all)
+    }
+
+    func testCharacterCRUD() {
+        let manager = CoreDataManager.shared
+        let character = manager.createCharacter(name: "TestChar", description: "desc")
+        var fetched = manager.fetchCharacters().first { $0.id == character.id }
+        XCTAssertNotNil(fetched)
+
+        var updated = character
+        updated.name = "UpdatedChar"
+        manager.updateCharacter(updated)
+
+        fetched = manager.fetchCharacters().first { $0.id == character.id }
+        XCTAssertEqual(fetched?.name, "UpdatedChar")
+
+        manager.deleteCharacter(character.id)
+        fetched = manager.fetchCharacters().first { $0.id == character.id }
+        XCTAssertNil(fetched)
+    }
+
+    func testSceneCRUD() {
+        let manager = CoreDataManager.shared
+        let scene = manager.createScene(title: "TestScene", description: "desc")
+        var fetched = manager.fetchScenes().first { $0.id == scene.id }
+        XCTAssertNotNil(fetched)
+
+        var updated = scene
+        updated.title = "UpdatedScene"
+        manager.updateScene(updated)
+        fetched = manager.fetchScenes().first { $0.id == scene.id }
+        XCTAssertEqual(fetched?.title, "UpdatedScene")
+
+        manager.deleteScene(scene.id)
+        fetched = manager.fetchScenes().first { $0.id == scene.id }
+        XCTAssertNil(fetched)
+    }
+
+    func testNoteCRUD() {
+        let manager = CoreDataManager.shared
+        let note = manager.createNote(title: "TestNote", content: "content")
+        var fetched = manager.fetchNotes().first { $0.id == note.id }
+        XCTAssertNotNil(fetched)
+
+        var updated = note
+        updated.title = "UpdatedNote"
+        manager.updateNote(updated)
+
+        fetched = manager.fetchNotes().first { $0.id == note.id }
+        XCTAssertEqual(fetched?.title, "UpdatedNote")
+
+        manager.deleteNote(note.id)
+        fetched = manager.fetchNotes().first { $0.id == note.id }
+        XCTAssertNil(fetched)
+    }
+}

--- a/AdventureRecordsTests/ExportAndCleanupTests.swift
+++ b/AdventureRecordsTests/ExportAndCleanupTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import AdventureRecords
+
+final class ExportAndCleanupTests: XCTestCase {
+    override func setUp() {
+        _ = CoreDataManager.shared.cleanupData(type: .all)
+        SampleDataGenerator.initializeData()
+    }
+
+    override func tearDown() {
+        _ = CoreDataManager.shared.cleanupData(type: .all)
+    }
+
+    func testExportJSONIncludesAllSections() throws {
+        let manager = CoreDataManager.shared
+        guard let document = manager.exportData(type: .json, includeCharacters: true, includeScenes: true, includeNotes: true) else {
+            XCTFail("Expected export document")
+            return
+        }
+        let jsonObject = try JSONSerialization.jsonObject(with: document.data, options: []) as? [String: Any]
+        XCTAssertNotNil(jsonObject?["characters"])
+        XCTAssertNotNil(jsonObject?["scenes"])
+        XCTAssertNotNil(jsonObject?["notes"])
+    }
+}

--- a/AdventureRecordsTests/SampleDataTests.swift
+++ b/AdventureRecordsTests/SampleDataTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import AdventureRecords
+
+final class SampleDataTests: XCTestCase {
+    override func setUp() {
+        _ = CoreDataManager.shared.cleanupData(type: .all)
+    }
+
+    override func tearDown() {
+        _ = CoreDataManager.shared.cleanupData(type: .all)
+    }
+
+    func testInitializeSampleDataCreatesRecords() {
+        SampleDataGenerator.initializeData()
+        let manager = CoreDataManager.shared
+        XCTAssertGreaterThan(manager.fetchCharacters().count, 0)
+        XCTAssertGreaterThan(manager.fetchScenes().count, 0)
+        XCTAssertGreaterThan(manager.fetchNotes().count, 0)
+    }
+
+    func testCleanupRemovesAllData() {
+        SampleDataGenerator.initializeData()
+        let manager = CoreDataManager.shared
+        XCTAssertFalse(manager.fetchCharacters().isEmpty)
+        let success = manager.cleanupData(type: .all)
+        XCTAssertTrue(success)
+        XCTAssertTrue(manager.fetchCharacters().isEmpty)
+        XCTAssertTrue(manager.fetchScenes().isEmpty)
+        XCTAssertTrue(manager.fetchNotes().isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- add a `BackupRestoreTests` case covering backup and restore flow
- add `AudioRecordingTests` for saving, updating and deleting audio recordings

## Testing
- `swift --version`
- `swift test | head` *(fails: Package.swift missing)*

------
https://chatgpt.com/codex/tasks/task_e_684203d265f083258fa509e7a2d0205c