### PR TITLE
Implement basic iCloud sync

### DIFF
--- a/AdventureRecords/Views/Common/Settings/SettingsView.swift
+++ b/AdventureRecords/Views/Common/Settings/SettingsView.swift
@@ -84,6 +84,9 @@ struct SettingsView: View {
                 Section(header: Text("云同步").foregroundColor(themeManager.secondaryTextColor)) {
                     Toggle("启用iCloud同步", isOn: $iCloudSync)
                         .toggleStyle(SwitchToggleStyle(tint: themeManager.accentColor(for: .character)))
+                        .onChange(of: iCloudSync) { newValue in
+                            CoreDataManager.shared.updateiCloudSync(newValue)
+                        }
 
                     if iCloudSync {
                         Picker("同步频率", selection: $syncFrequency) {
@@ -94,7 +97,7 @@ struct SettingsView: View {
                         }
 
                         Button(action: {
-                            // 手动同步实现
+                            CoreDataManager.shared.manualSync()
                         }) {
                             Label("立即同步", systemImage: "arrow.clockwise")
                                 .foregroundColor(themeManager.accentColor(for: .character))


### PR DESCRIPTION
## Summary
- switch CoreData stack to NSPersistentCloudKitContainer when iCloud sync is enabled
- add hooks in Settings to toggle iCloud sync and trigger manual sync

## Testing
- `swift --version`
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420caef6548325b7fc506c12d3d03c